### PR TITLE
Fixed build problems (hash mismatch and double patch application)

### DIFF
--- a/unwrapped.nix
+++ b/unwrapped.nix
@@ -47,14 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-bFGk8lqPlNlaxbrulYe0+8ayj33frctruce3/TZ+W2c=";
   };
 
-  # fix build failure with Qt 6.10
-  patches = fetchpatch2 {
-    name = "fix-build-with-qt-610.patch";
-    url = "https://github.com/desktop-app/cmake_helpers/commit/682f1b57.patch";
-    hash = "sha256-DHwgxAEFc1byQkVvrPwyctQKvUsK/KQ/cnzRv6PQuTM=";
-    stripLen = 1;
-    extraPrefix = "cmake/";
-  };
+  patches = [];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
- Updated AyuGram sources hash (build failed due to hash mismatch)
- QT patch was causing fail:
```
applying patch /nix/store/...-fix-build-with-qt-610.patch
patching file cmake/external/qt/package.cmake
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file cmake/external/qt/package.cmake.rej
```
But in AyuGram 6.2.4, the vendored `cmake_helpers` submodule already contains that commit (or equivalent changes), so applying it again fails.
I removed the patch.