### PR TITLE
chore(dependencies): rename minizip -> minizip-ng

### DIFF
--- a/unwrapped.nix
+++ b/unwrapped.nix
@@ -16,7 +16,7 @@
   ffmpeg_6,
   protobuf,
   openal-soft,
-  minizip,
+  minizip-ng,
   range-v3,
   tl-expected,
   hunspell,
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     xxHash
     ffmpeg_6
     openal-soft
-    minizip
+    minizip-ng
     range-v3
     tl-expected
     rnnoise


### PR DESCRIPTION
Just tried rebuilding AyuGram once again and it's successfully failed.

The [PR 491464](https://github.com/NixOS/nixpkgs/pull/491464) dated 18 Feb into Nixpkgs repository updates zlib 1.3.1 to 1.3.2.
As [mentioned](https://github.com/NixOS/nixpkgs/pull/491464#issuecomment-4030903430) in the discussion of this PR, the transition introduces [breaking change](https://github.com/madler/zlib/commit/7e6f0784cc0c33e8d5fcb368248168c6656f73c8), i.e. headers are now should be accessed via `minizip/hdr.h` and not just `hdr.h`.
This leads to errors like this:
```
In file included from /build/source/Telegram/SourceFiles/chat_helpers/spellchecker_common.cpp:13:
/build/source/Telegram/lib_base/base/zlib_help.h:9:10: fatal error: zip.h: No such file or directory
    9 | #include <zip.h>
      |          ^~~~~~~
compilation terminated.
```
and the same with `unzip.h`.

Since none of our upstreams (telegram-desktop, ayugram-desktop) hasn't yet transitioned, we have to do something about it.
There already was a related [issue 497549](https://github.com/NixOS/nixpkgs/issues/497549) on Nixpkgs repository about `telegram-desktop` package facing this problem.
A solution using [patch](https://github.com/NixOS/nixpkgs/issues/497549#issuecomment-4017856407) was suggested
```
diff --git a/Telegram/lib_base/base/zlib_help.h b/Telegram/lib_base/base/zlib_help.h
index af871ee..cc7e419 100644
--- a/Telegram/lib_base/base/zlib_help.h
+++ b/Telegram/lib_base/base/zlib_help.h
@@ -6,7 +6,7 @@
 //
 #pragma once
 
-#include <zip.h>
-#include <unzip.h>
+#include <minizip/zip.h>
+#include <minizip/unzip.h>
 #include "logs.h"
```
However after negotiation it's [decided](https://github.com/NixOS/nixpkgs/issues/497549#issuecomment-4043235523) to use `minizip-ng` instead of `minizip`. Now `telegram-desktop` on both [NixOS-25.11](https://github.com/NixOS/nixpkgs/pull/499107/changes) and [NixOS-unstable](https://github.com/NixOS/nixpkgs/commit/972f98b1b374b41b3bde77cae0db073627e02ce9) branches is being built using `minizip-ng` instead of `minizip`.
So I just don't see a problem to do the same instead of patching sources.

### References:
- Problem description:
   https://github.com/NixOS/nixpkgs/issues/497549
- Nixpkgs update, causing problem:
  https://github.com/NixOS/nixpkgs/pull/491464
- `zlib` upstream breaking change:
  https://github.com/madler/zlib/commit/7e6f0784cc0c33e8d5fcb368248168c6656f73c8
- Breaking change description:
  https://github.com/NixOS/nixpkgs/pull/491464#issuecomment-4030903430
- Mitigation for `telegram-desktop` on Nixpkgs:
  https://github.com/NixOS/nixpkgs/pull/499107