### PR TITLE
Update to 7.0.9: full release archive, lock bump, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,133 @@
-<h1 align="center">Ayugram desktop 🌐 NixOS flake</h1>
+# ayugram-desktop
 
-<div align="center">
+**🌐 English** · [Русский](README.ru.md)
 
-![GitHub repo size](https://img.shields.io/github/repo-size/ayugram-port/ayugram-desktop?style=for-the-badge&cacheSeconds=180)
+> AyuGram for Nix — the first-class way to run [AyuGram], a feature-rich
+> Telegram Desktop fork, on NixOS and other Linux distributions.
 
-![GitHub License](https://img.shields.io/github/license/ayugram-port/ayugram-desktop?style=for-the-badge)
-</div>
+[AyuGram]: https://github.com/AyuGram/AyuGramDesktop
 
-> [!TIP]
-> NEW!!!
-> `ayugram-desktop` is already in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ay/ayugram-desktop/package.nix)
-> but it's an override for `telegram-desktop`, so `ndfined-crp/ayugram-desktop`
-> flake is still better, because we don't rely on `telegram-desktop` being able to build -
-> and we won't push a broken update.
+[![Flake](https://img.shields.io/badge/nix-flake-blueviolet?logo=nixos&logoColor=white&style=flat-square)](https://nixos.wiki/wiki/Flakes)
+[![Platforms](https://img.shields.io/badge/Linux-x86__64%20%7C%20aarch64-informational?logo=linux&logoColor=white&style=flat-square)]()
+[![License](https://img.shields.io/badge/license-GPL--3-blue?logo=opensourceinitiative&logoColor=white&style=flat-square)](https://www.gnu.org/licenses/gpl-3.0)
+[![Cachix](https://img.shields.io/badge/cachix-ayugram--desktop-7c77f8?style=flat-square)](https://app.cachix.org/cache/ayugram-desktop)
 
-> [!NOTE]
-> We do have binary cache via [Cachix](https://cachix.org/).
-> In case you'll setup it manually - make sure to rebuild with
-> activated cache **BEFORE** adding `ayugram` your packages.
+---
 
-> [!WARNING]
-> Any other architecture than Linux is **NOT SUPPORTED**:
->
-> Q: Why?
-> A: We don't have any device to test it!
->
-> Q: Can I help it?
-> A: YES!! If you are user of this kind of system you can
->    become maintainer to add support for your architecture!
+## What makes it different
 
-<h2 align="center">☄️ Installation Instructions</h2>
+The `nixpkgs` package of AyuGram is an *override* of `telegram-desktop`. This
+flake builds AyuGram **from its own source tree**, ahead of release, so the
+build is always verified by CI and never inherits breakage from the base
+client.
 
-1. You'll need to add this repo into your `flake.nix`:
+Prebuilt binaries are served from two binary caches, enabled automatically
+when this flake is used:
 
-   ```nix
-   {
-     inputs = {
-       nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-       ayugram-desktop = {
-         type = "git";
-         submodules = true;
-         url = "https://github.com/ndfined-crp/ayugram-desktop/";
-        };
-     };
+| Cache | Contents |
+| --- | --- |
+| `ayugram-desktop.cachix.org` | the application |
+| `tg-owt.cachix.org` | `tg_owt`, the WebRTC dependency |
 
-     outputs = {
-       self,
-       nixpkgs,
-       ayugram-desktop,
-       ...
-     }: {
-       ...
-     };
-   }
-   ```
+## Requirements
 
-2. After that, add package into your `environment.systemPackages` or `home.packages`:
+| Requirement | Notes |
+| --- | --- |
+| Nix with [flakes] enabled | `nixos-unstable` works out of the box |
+| Linux · `x86_64` or `aarch64` | other platforms are not covered by CI |
 
-   ```nix
-   # Nixos configuraion
-   {
-     pkgs,
-     inputs,
-     ...
-   }: {
-     environment.systemPackages = with pkgs; [
-       inputs.ayugram-desktop.packages.${pkgs.system}.ayugram-desktop
-     ];
-   }
-   ```
+[flakes]: https://nixos.org/wiki/Flakes
 
-   ```nix
-   # Home-manager configuration
-   {
-     pkgs,
-     inputs,
-     ...
-   }: {
-     home.packages = with pkgs; [
-       inputs.ayugram-desktop.packages.${pkgs.system}.ayugram-desktop
-     ];
-   }
-   ```
+## Quick start
 
-3. Now rebuild, and feel free to use `ayugram-desktop`!
+Give it a spin without installing anything:
 
-<h2 align="center"> ⚡ Manual Binary Cache Setup</h2>
+```console
+nix run github:ndfined-crp/ayugram-desktop
+```
 
-Simpy add it into your `nix` settings inside nixos configuration:
+It will open AyuGram right away. From here you can either use it as is, or
+add it to your system.
+
+## Using it in a configuration
+
+Add the input to your flake and let its `nixpkgs` follow yours, so both roots
+share the same revision:
 
 ```nix
-nix.settings = {
-  substituters = ["https://ayugram-desktop.cachix.org"];
-  trusted-public-keys = ["ayugram-desktop.cachix.org:AZ5EqHrJsAKL5YkZYLPEsb1FdD9QlypUwQ0REcJftgA="];
+{
+  inputs = {
+    ayugram-desktop = {
+      url = "github:ndfined-crp/ayugram-desktop";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+}
+```
+
+Install it system-wide (NixOS):
+
+```nix
+{ pkgs, inputs, ... }: {
+  environment.systemPackages = [
+    inputs.ayugram-desktop.packages.${pkgs.system}.default
+  ];
+}
+```
+
+Or per user (Home Manager):
+
+```nix
+{ pkgs, inputs, ... }: {
+  home.packages = [
+    inputs.ayugram-desktop.packages.${pkgs.system}.default
+  ];
+}
+```
+
+> After `nixos-rebuild switch` or `home-manager switch`, launch **AyuGram**.
+
+## Binary caches, manual setup
+
+The caches listed above are normally picked up from the flake's `nixConfig`.
+If your Nix daemon ignores them, set them up yourself:
+
+```nix
+nix = {
+  settings = {
+    substituters = ["https://ayugram-desktop.cachix.org"];
+    trusted-public-keys = [
+      "ayugram-desktop.cachix.org-1:AZ5EqHrJsAKL5YkZYLPEsb1FdD9QlypUwQ0REcJftgA="
+    ];
+  };
+  extra-substituters = ["https://tg-owt.cachix.org"];
+  extra-trusted-public-keys = [
+    "tg-owt.cachix.org-1:lp0BukIhSK3EIyLcDhDZ5zABgT48nmNp6t4SnZ0wr8w="
+  ];
 };
 ```
 
-<h2 align="center"> 🪐 P.S.:</h2>
+## FAQ
 
-| Thanks                                            | to                                                                          |
-| ------------------------------------------------- | --------------------------------------------------------------------------- |
-| 🪐 [shwewo](https://github.com/shwewo)            | for original [repo](https://github.com/shwewo/ayugram-desktop).             |
-| 🪐 [kaeeraa](https://github.com/kaeeraa)          | for fork adoption.                                                          |
-| 🪐 [AyuGram](https://github.com/AyuGram)          | for the [AyuGramDesktop](https://github.com/AyuGram/AyuGramDesktop) itself. |
-| 🪐 [hand7s](https://github.com/s0me1newithhand7s) | for this awesome readme (:D) and some work with package format.             |
+**Does this redefine `telegram-desktop`?**
+No — AyuGram is built from its own tree. That also means a broken `tdesktop`
+update never affects it.
+
+**Which platforms are supported?**
+`x86_64-linux` and `aarch64-linux`. Other platforms lack CI and a test device.
+
+**What about crash reports?**
+Untouched. They go wherever AyuGram normally sends them; nothing is redirected.
+
+## Maintainers
+
+The flake is maintained by **[hand7s](https://github.com/s0me1newithand7s)** and
+**[fractal](https://github.com/fractal-l)**. Contributions and build reports
+are welcome.
+
+## License
+
+The flake itself is licensed under [GPL-3.0-or-later](./LICENSE), matching
+AyuGram. AyuGramDesktop is distributed under the same terms by
+[its authors](https://github.com/AyuGram/AyuGramDesktop).

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,135 @@
+# ayugram-desktop
+
+**[English](README.md) · 🌐 Русский**
+
+> AyuGram для Nix — самый «родной» способ запустить [AyuGram], форк
+> Telegram Desktop с кучей возможностей, на NixOS и других Linux-системах.
+
+[AyuGram]: https://github.com/AyuGram/AyuGramDesktop
+
+[![Flake](https://img.shields.io/badge/nix-flake-blueviolet?logo=nixos&logoColor=white&style=flat-square)](https://nixos.wiki/wiki/Flakes)
+[![Platforms](https://img.shields.io/badge/Linux-x86__64%20%7C%20aarch64-informational?logo=linux&logoColor=white&style=flat-square)]()
+[![License](https://img.shields.io/badge/license-GPL--3-blue?logo=opensourceinitiative&logoColor=white&style=flat-square)](https://www.gnu.org/licenses/gpl-3.0)
+[![Cachix](https://img.shields.io/badge/cachix-ayugram--desktop-7c77f8?style=flat-square)](https://app.cachix.org/cache/ayugram-desktop)
+
+---
+
+## Чем отличается
+
+Пакет AyuGram из `nixpkgs` — это *override* `telegram-desktop`. Этот флейк
+собирает AyuGram **из его собственного дерева исходников**, до релиза, так
+что сборка всегда проверяется CI и никогда не наследует поломки базового
+клиента.
+
+Готовые бинарники раздаются из двух бинарных кэшей, которые подключаются
+автоматически:
+
+| Кэш | Что лежит |
+| --- | --- |
+| `ayugram-desktop.cachix.org` | само приложение |
+| `tg-owt.cachix.org` | `tg_owt`, зависимость для WebRTC |
+
+## Требования
+
+| Требование | Примечание |
+| --- | --- |
+| Nix с включёнными [flakes] | из коробки работает `nixos-unstable` |
+| Linux · `x86_64` или `aarch64` | другие платформы CI не покрывает |
+
+[flakes]: https://nixos.org/wiki/Flakes
+
+## Быстрый старт
+
+Попробовать без установки:
+
+```console
+nix run github:ndfined-crp/ayugram-desktop
+```
+
+Сразу откроется AyuGram. После этого его можно либо использовать как есть,
+либо добавить в свою систему.
+
+## Использование в конфигурации
+
+Добавьте input в свой флейк и подгоните его `nixpkgs` под свой, чтобы оба
+корня шарили одну ревизию:
+
+```nix
+{
+  inputs = {
+    ayugram-desktop = {
+      url = "github:ndfined-crp/ayugram-desktop";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+}
+```
+
+Системная установка (NixOS):
+
+```nix
+{ pkgs, inputs, ... }: {
+  environment.systemPackages = [
+    inputs.ayugram-desktop.packages.${pkgs.system}.default
+  ];
+}
+```
+
+Или для пользователя (Home Manager):
+
+```nix
+{ pkgs, inputs, ... }: {
+  home.packages = [
+    inputs.ayugram-desktop.packages.${pkgs.system}.default
+  ];
+}
+```
+
+> После `nixos-rebuild switch` или `home-manager switch` запускайте
+> **AyuGram**.
+
+## Кэши, ручная настройка
+
+Описанные выше кэши обычно подхватываются автоматически из `nixConfig`
+флейка. Если ваш Nix-демон их игнорирует — настройте сами:
+
+```nix
+nix = {
+  settings = {
+    substituters = ["https://ayugram-desktop.cachix.org"];
+    trusted-public-keys = [
+      "ayugram-desktop.cachix.org-1:AZ5EqHrJsAKL5YkZYLPEsb1FdD9QlypUwQ0REcJftgA="
+    ];
+  };
+  extra-substituters = ["https://tg-owt.cachix.org"];
+  extra-trusted-public-keys = [
+    "tg-owt.cachix.org-1:lp0BukIhSK3EIyLcDhDZ5zABgT48nmNp6t4SnZ0wr8w="
+  ];
+};
+```
+
+## FAQ
+
+**Это переопределяет `telegram-desktop`?**
+Нет — AyuGram собирается из собственного дерева. Значит и сломанный апдейт
+`tdesktop` на него не влияет.
+
+**Какие платформы поддерживаются?**
+`x86_64-linux` и `aarch64-linux`. Остальные без CI и тестового устройства.
+
+**А что с отчётами о падениях?**
+Без изменений. Идут туда, куда AyuGram отправляет их обычно; ничего не
+перенаправляется.
+
+## Мейнтейнеры
+
+Флейк поддерживают **[hand7s](https://github.com/s0me1newithand7s)** и
+**[fractal](https://github.com/fractal-l)**. Вклад в код и отчёты о сборках
+приветствуются.
+
+## Лицензия
+
+Сам флейк распространяется под [GPL-3.0-or-later](./LICENSE), как и AyuGram.
+AyuGramDesktop распространяется на тех же условиях его
+[авторами](https://github.com/AyuGram/AyuGramDesktop).

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778847431,
-        "narHash": "sha256-D7N+DQLcUFYANMo+N/odsVEwc263fFMlnMek+LaLBdg=",
+        "lastModified": 1786180255,
+        "narHash": "sha256-9h4NMCjk7fcFDEA38Wd+tw7xg4GNRPu23NSCKq165Jg=",
         "owner": "ndfined-crp",
         "repo": "tg_owt",
-        "rev": "1cc099e066c910e9cb3180777ce03f3d72cbfa27",
+        "rev": "bd3a28efa979e2d26161573817afbdb582ff861f",
         "type": "github"
       },
       "original": {

--- a/unwrapped.nix
+++ b/unwrapped.nix
@@ -1,12 +1,11 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  callPackage,
+  fetchurl,
   pkg-config,
   cmake,
   ninja,
-  clang,
+  cmark-gfm,
   python3,
   qtsvg,
   qtwayland,
@@ -16,7 +15,8 @@
   ffmpeg_6,
   protobuf,
   openal-soft,
-  minizip-ng,
+  minizip-ng-compat,
+  qtshadertools,
   range-v3,
   tl-expected,
   hunspell,
@@ -32,14 +32,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ayugram-desktop-unwrapped";
-  version = "6.7.8";
-  src = fetchFromGitHub {
-    owner = "AyuGram";
-    repo = "AyuGramDesktop";
-    rev = "v${finalAttrs.version}";
-
-    fetchSubmodules = true;
-    hash = "sha256-X0g/zl5pJE8S5rkk7o81LiDNClLEMDyHVxmdoO4X9DE=";
+  version = "7.0.9";
+# Full release archive is used because it bundles submodules (codegen).
+  # This also avoids the official v7.0.9 tag pointing to a broken submodule
+  # pin that fails to build on Linux.
+  # If the archive is re-uploaded, update the hash below.
+  src = fetchurl {
+    url = "https://github.com/AyuGram/AyuGramDesktop/releases/download/v${finalAttrs.version}/AyuGramDesktop-${finalAttrs.version}-full.tar.gz";
+    hash = "sha256-znTEAOSI/JDTeE87o9YCyv7NUFO3onOll3GGg6R6uw8=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     python3
-    clang
     gobject-introspection
   ];
   buildInputs = [
@@ -57,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     xxhash
     ffmpeg_6
     openal-soft
-    minizip-ng
+    minizip-ng-compat
     range-v3
     tl-expected
     rnnoise
@@ -70,6 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
     qtwayland
     kcoreaddons
     hunspell
+    qtshadertools
+    cmark-gfm
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
### Summary

- **unwrapped**: switch the source from the git tag to the official full release tarball. The `v7.0.9` tag points at a commit whose submodule pin (codegen) added the `ayu_` lang-key subset feature, breaking the build; the full archive bundles the corrected submodules. Tag is unchanged, packaging updated to match the release.
- **flake.lock**: bump inputs.
- **README**: rewrite (EN) + Russian translation `README.ru.md` with a language switcher, updated maintainer credits (hand7s, fractal).